### PR TITLE
潅流の合併症がJOED旧バージョンの様式であったため修正.

### DIFF
--- a/schema/treatment/operation_adverse_events.json
+++ b/schema/treatment/operation_adverse_events.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../jesgo.json",
     "$id": "/schema/treatment/operation_adverse_events",
-    "jesgo:version": "1.2",
+    "jesgo:version": "1.3",
     "title": "手術合併症",
     "type": "object",
     "jesgo:unique": false,
@@ -156,13 +156,13 @@
                         "items": {
                             "type": "string",
                             "enum": [
-                                "皮下気腫",
+                                "気腫",
                                 "ガス塞栓(炭酸ガス)",
                                 "ガス塞栓(空気)",
                                 "水中毒",
-                                "そのほか心臓障害",
-                                "そのほか呼吸器障害",
-                                "そのほか神経系障害",
+                                "その他 循環器系障害",
+                                "その他 呼吸器系障害",
+                                "その他 神経系障害",
                                 "上記以外"
                             ],
                             "minItems": 1


### PR DESCRIPTION
手術合併症の気腹潅流に関する合併症がJOED5 1.2様式であったため修正。

これにともない、当該の合併症については削除の上で再入力が必要になります。
それほど件数は多くないと思われるので修正スクリプトは不要で制限事項としてよいかと思います。
（JOED5出力プラグインでは自動修正します）