### PR TITLE
スキーマ operation_procedures をarrayからオブジェクトに変更

### DIFF
--- a/schema/treatment/operation_procedures.json
+++ b/schema/treatment/operation_procedures.json
@@ -3,10 +3,16 @@
     "$id": "/schema/treatment/operation_procedures",
     "jesgo:version": "1.1",
     "jesgo:unique": true,
-    "type": "array",
+    "type": "object",
     "title": "実施手術",
-    "items": {
-        "$ref": "#/$defs/procedure"
+    "properties": {
+        "実施手術": {
+            "type": "array",
+            "description": "主たる術式を最初の行に配置してください.",
+            "items": {
+                "$ref": "#/$defs/procedure"
+            }
+        }
     },
     "$defs": {
         "procedure": {


### PR DESCRIPTION
オブジェクト以外を生成するスキーマだといろいろ不具合が生じるので大鉈を振るって修正。

あわせて既存ドキュメントの修正SQL:
```
UPDATE jesgo_document SET
  document =  jsonb_set('{"実施手術": []}'::jsonb, '{実施手術}', document)
WHERE
  schema_id IN (SELECT schema_id FROM jesgo_document_schema WHERE schema_id_string = '/schema/treatment/operation_procedures')
  AND
  jsonb_typeof(document) = 'array';
```
