### PR TITLE
術後合併症をJOED完全準拠に

### DIFF
--- a/schema/treatment/operation.json
+++ b/schema/treatment/operation.json
@@ -86,6 +86,9 @@
         "合併症の有無": {
             "type": "string",
             "jesgo:tag": "has_complications",
+            "jesgo:required": [
+                "JSGOE"
+            ],
             "enum": [
                 "なし",
                 "あり"

--- a/schema/treatment/operation_adverse_events.json
+++ b/schema/treatment/operation_adverse_events.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../jesgo.json",
     "$id": "/schema/treatment/operation_adverse_events",
-    "jesgo:version": "1.5",
+    "jesgo:version": "1.6",
     "title": "手術合併症",
     "type": "object",
     "jesgo:unique": false,
@@ -375,198 +375,98 @@
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "anyOf": [
+                            "oneOf": [
                                 {
-                                    "type": "string",
                                     "enum": [
-                                        "出血"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "出血",                                         
                                         "血腫"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "創部感染"
+                                        "創部感染",
+                                        "創離開",
+                                        "腟断端部離開",
+                                        "メッシュ露出"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "創離開"
+                                        "腹膜炎",
+                                        "子宮感染",
+                                        "卵管・卵巣感染",
+                                        "メッシュ感染"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "腟断端部離開"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "腹膜炎"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "子宮感染"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "卵管・卵巣感染"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "イレウス"
-                                    ],
-                                    "title": "イレウス(腸管麻痺)"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "消化管穿孔",
+                                        "イレウス",
                                         "腸閉塞"
-                                    ],
-                                    "title": "腸閉塞(機械的閉塞・絞扼性イレウス)"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "消化管穿孔"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
                                         "腹壁瘢痕・ポートサイトヘルニア"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "尿管損傷"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "尿路閉塞"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "膀胱損傷"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "尿管損傷",
+                                        "尿路閉塞",
+                                        "膀胱損傷",
                                         "その他 尿路系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "肺動脈血栓塞栓症"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "深部静脈血栓症"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "心肺停止"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "肺動脈血栓塞栓症",
+                                        "深部静脈血栓症",
+                                        "心肺停止",
                                         "その他 循環器系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "気胸"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "気胸",
                                         "その他 呼吸器系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "コンパートメント症候群"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "コンパートメント症候群",
                                         "その他 骨軟部系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "上肢神経障害"
+                                        "上肢神経障害",
+                                        "下肢神経障害",
+                                        "その他 神経系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "下肢神経障害"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "リンパ浮腫"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "非感染性リンパ嚢胞"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "リンパ浮腫",
+                                        "非感染性リンパ嚢胞",
                                         "感染性リンパ嚢胞・後腹膜膿瘍"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "子宮腔からの出血持続"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "子宮腔の癒着"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "子宮腔からの出血持続",
+                                        "子宮腔の癒着",
                                         "卵管閉塞"
                                     ]
                                 }
@@ -703,62 +603,34 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "anyOf": [
+                "oneOf": [
                     {
-                        "type": "string",
                         "enum": [
-                            "子宮"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "卵管"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "卵巣"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "子宮",
+                            "卵管",
+                            "卵巣",
                             "腟"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "膀胱"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "膀胱",
                             "尿管"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "後腹膜"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "直腸"
-                        ],
-                        "title": "消化管(直腸)"
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "直腸",
                             "結腸"
-                        ],
-                        "title": "消化管(結腸)"
+                        ]
                     },
                     {
                         "type": "string",
@@ -768,62 +640,36 @@
                         "title": "消化管(その他)"
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "腹壁"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "腹壁血管"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "腹壁",
+                            "腹壁血管",
                             "皮下"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "動脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "静脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "大血管動脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "動脈",
+                            "静脈",
+                            "大血管動脈",
                             "大血管静脈"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "神経"
                         ]
                     },
                     {
-                        "type": "string",
                         "enum": [
                             "骨格系"
                         ],
                         "title": "骨・骨膜・軟骨"
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "上記にない部位"
                         ]

--- a/schema/treatment/operation_detailed.json
+++ b/schema/treatment/operation_detailed.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../jesgo.json",
     "$id": "/schema/treatment/operation/detailed",
-    "jesgo:version": "1.6",
+    "jesgo:version": "2.0",
     "jesgo:valid": ["2023-09-02"],
     "type": "object",
     "title": "手術療法 詳細",
@@ -107,10 +107,12 @@
             ]
         },
         "残存腫瘍部位": {
-            "type": "string"
+            "type": "string",
+            "jesgo:ui:textarea": true
         },
         "腹腔内所見": {
-            "type": "string"
+            "type": "string",
+            "jesgo:ui:textarea": true
         },
         "内性器の摘出状態": {
             "type": "object",
@@ -153,6 +155,9 @@
         "合併症の有無": {
             "type": "string",
             "jesgo:tag": "has_complications",
+            "jesgo:required": [
+                "JSGOE"
+            ],
             "enum": [
                 "なし",
                 "あり"

--- a/schema_v1.0/treatment/operation.json
+++ b/schema_v1.0/treatment/operation.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../jesgo.json",
     "$id": "/schema/treatment/operation",
-    "jesgo:version": "1.1",
+    "jesgo:version": "1.2",
     "type": "object",
     "title": "手術療法",
     "jesgo:ui:subschemastyle": "tab",
@@ -10,7 +10,10 @@
             "type": "string",
             "format": "date",
             "jesgo:set": "eventdate",
-            "jesgo:tag": "treatment_surgery"
+            "jesgo:tag": "treatment_surgery",
+            "jesgo:required": [
+                "JSGOE"
+            ]
         },
         "手術時間": {
             "description": "加刀~終刀までの時間(分) もしくは 時:分 で入力",
@@ -24,6 +27,9 @@
                     "type": "string",
                     "pattern": "^([1-9][0-9]?:)?[0-5]?[0-9]$"
                 }
+            ],
+            "jesgo:required": [
+                "JSGOE"
             ]
         },
         "出血量": {
@@ -78,6 +84,9 @@
         "合併症の有無": {
             "type": "string",
             "jesgo:tag": "has_complications",
+            "jesgo:required": [
+                "JSGOE"
+            ],
             "enum": [
                 "なし",
                 "あり"

--- a/schema_v1.0/treatment/operation_adverse_events.json
+++ b/schema_v1.0/treatment/operation_adverse_events.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../jesgo.json",
     "$id": "/schema/treatment/operation_adverse_events",
-    "jesgo:version": "1.5",
+    "jesgo:version": "1.6",
     "title": "手術合併症",
     "type": "object",
     "jesgo:unique": false,
@@ -375,198 +375,98 @@
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "anyOf": [
+                            "oneOf": [
                                 {
-                                    "type": "string",
                                     "enum": [
-                                        "出血"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "出血",                                         
                                         "血腫"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "創部感染"
+                                        "創部感染",
+                                        "創離開",
+                                        "腟断端部離開",
+                                        "メッシュ露出"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "創離開"
+                                        "腹膜炎",
+                                        "子宮感染",
+                                        "卵管・卵巣感染",
+                                        "メッシュ感染"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "腟断端部離開"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "腹膜炎"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "子宮感染"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "卵管・卵巣感染"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "イレウス"
-                                    ],
-                                    "title": "イレウス(腸管麻痺)"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "消化管穿孔",
+                                        "イレウス",
                                         "腸閉塞"
-                                    ],
-                                    "title": "腸閉塞(機械的閉塞・絞扼性イレウス)"
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "消化管穿孔"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
                                         "腹壁瘢痕・ポートサイトヘルニア"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "尿管損傷"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "尿路閉塞"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "膀胱損傷"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "尿管損傷",
+                                        "尿路閉塞",
+                                        "膀胱損傷",
                                         "その他 尿路系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "肺動脈血栓塞栓症"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "深部静脈血栓症"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "心肺停止"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "肺動脈血栓塞栓症",
+                                        "深部静脈血栓症",
+                                        "心肺停止",
                                         "その他 循環器系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "気胸"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "気胸",
                                         "その他 呼吸器系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "コンパートメント症候群"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "コンパートメント症候群",
                                         "その他 骨軟部系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "上肢神経障害"
+                                        "上肢神経障害",
+                                        "下肢神経障害",
+                                        "その他 神経系障害"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "下肢神経障害"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "リンパ浮腫"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "非感染性リンパ嚢胞"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "リンパ浮腫",
+                                        "非感染性リンパ嚢胞",
                                         "感染性リンパ嚢胞・後腹膜膿瘍"
                                     ]
                                 },
                                 {
-                                    "type": "string",
+                                    "title": "──",
                                     "enum": [
-                                        "子宮腔からの出血持続"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "子宮腔の癒着"
-                                    ]
-                                },
-                                {
-                                    "type": "string",
-                                    "enum": [
+                                        "子宮腔からの出血持続",
+                                        "子宮腔の癒着",
                                         "卵管閉塞"
                                     ]
                                 }
@@ -703,62 +603,34 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "anyOf": [
+                "oneOf": [
                     {
-                        "type": "string",
                         "enum": [
-                            "子宮"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "卵管"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "卵巣"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "子宮",
+                            "卵管",
+                            "卵巣",
                             "腟"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "膀胱"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "膀胱",
                             "尿管"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "後腹膜"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "直腸"
-                        ],
-                        "title": "消化管(直腸)"
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "直腸",
                             "結腸"
-                        ],
-                        "title": "消化管(結腸)"
+                        ]
                     },
                     {
                         "type": "string",
@@ -768,62 +640,36 @@
                         "title": "消化管(その他)"
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "腹壁"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "腹壁血管"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "腹壁",
+                            "腹壁血管",
                             "皮下"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
-                            "動脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "静脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "大血管動脈"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
+                            "動脈",
+                            "静脈",
+                            "大血管動脈",
                             "大血管静脈"
                         ]
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "神経"
                         ]
                     },
                     {
-                        "type": "string",
                         "enum": [
                             "骨格系"
                         ],
                         "title": "骨・骨膜・軟骨"
                     },
                     {
-                        "type": "string",
+                        "title": "──",
                         "enum": [
                             "上記にない部位"
                         ]

--- a/schema_v1.0/treatment/operation_detailed.json
+++ b/schema_v1.0/treatment/operation_detailed.json
@@ -9,7 +9,10 @@
             "type": "string",
             "format": "date",
             "jesgo:set": "eventdate",
-            "jesgo:tag": "treatment_surgery"
+            "jesgo:tag": "treatment_surgery",
+            "jesgo:required": [
+                "JSGOE"
+            ]
         },
         "手術時間": {
             "description": "加刀~終刀までの時間(分) もしくは 時:分 で入力",
@@ -23,6 +26,9 @@
                     "type": "string",
                     "pattern": "^([1-9][0-9]?:)?[0-5]?[0-9]$"
                 }
+            ],
+            "jesgo:required": [
+                "JSGOE"
             ]
         },
         "麻酔方法": {
@@ -145,7 +151,9 @@
         "合併症の有無": {
             "type": "string",
             "jesgo:tag": "has_complications",
-
+            "jesgo:required": [
+                "JSGOE"
+            ],
             "enum": [
                 "なし",
                 "あり"


### PR DESCRIPTION
いくつか不要とされていたもの（メッシュ感染）を実装し、選択枝にセパレーターもどきを実装しました。
![image](https://github.com/jesgo-toitu/jesgo-schema/assets/57445173/e6f3aa47-0182-4f24-b497-18f6eaf80637)

ついでに、手術スキーマに"jesgo:required": ["JSGOE"]を設定しています。

DB直叩きしているので相変わらず、バージョンはぐちゃぐちゃです。リリースの時に修正をお願いいたします。